### PR TITLE
Video LoadURL cross origin support.

### DIFF
--- a/src/gameobjects/video/Video.js
+++ b/src/gameobjects/video/Video.js
@@ -811,10 +811,11 @@ var Video = new Class({
      * @param {string} url - The URL of the video to load or be streamed.
      * @param {string} [loadEvent='loadeddata'] - The load event to listen for. Either `loadeddata`, `canplay` or `canplaythrough`.
      * @param {boolean} [noAudio=false] - Does the video have an audio track? If not you can enable auto-playing on it.
+     * @param {string} [crossOrigin] - The value to use for the `crossOrigin` property in the video load request.  Either undefined, `anonymous` or `use-credentials`
      *
      * @return {this} This Video Game Object for method chaining.
      */
-    loadURL: function (url, loadEvent, noAudio)
+    loadURL: function (url, loadEvent, noAudio, crossOrigin)
     {
         if (loadEvent === undefined) { loadEvent = 'loadeddata'; }
         if (noAudio === undefined) { noAudio = false; }
@@ -843,6 +844,10 @@ var Video = new Class({
 
         video.setAttribute('playsinline', 'playsinline');
         video.setAttribute('preload', 'auto');
+
+        if(crossOrigin !== undefined) {
+            video.setAttribute('crossorigin', crossOrigin);
+        }
 
         video.addEventListener('error', this._callbacks.error, true);
 


### PR DESCRIPTION
Please do not update the README or Change Log, we will do this when we merge your PR.

This PR (delete as applicable)

* Adds a new feature

Describe the changes below:

Added a 4th parameter to video.loadURL to allow cross origin support.  The existing system did not allow for this, since the video element is created at this point.

I looked at adding it based off the default sceneConfig, and that is possible, but would likely require an additional setCors function to mimic the loader methodology, and that seems somewhat counterintuitive to me, since it's only this loadUrl function that needs this; if you load the video using the loader, it already uses the old method. 